### PR TITLE
Renames property `repoType` to `repoName`

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -22,7 +22,7 @@ class BintrayConfiguration {
             publications = extension.publications
 
             pkg {
-                repo = extension.repoType
+                repo = extension.repoName
                 userOrg = extension.userOrg
                 name = extension.uploadName
                 desc = extension.description

--- a/core/src/main/groovy/com/novoda/gradle/release/PublishExtension.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/PublishExtension.groovy
@@ -2,7 +2,7 @@ package com.novoda.gradle.release
 
 class PublishExtension {
 
-    String repoType = 'maven'
+    String repoName = 'maven'
     String userOrg
 
     String groupId


### PR DESCRIPTION
Renames property `repoType` to `repoName`

Fixes #17

Since we're in a really early stage, I don't think we need to keep the old name and deprecate
