### PR TITLE
22/Use version property if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'bintray-release'
-    version = '0.2.8'
-    description = 'Oh hi, this is a nice description for a project right?'
+    version = '0.2.8'             // since 0.2.8, version can also be supplied on the command line. [See here](https://github.com/novoda/bintray-release/pull/23)
+    description = 'Oh hi, this is a nice description for a project, right?'
     website = 'https://github.com/novoda/bintray-release'
 }
 ```

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'bintray-release'
-    version = '0.2.8'             // since 0.2.8, version can also be supplied on the command line. [See here](https://github.com/novoda/bintray-release/pull/23)
+    version = '0.2.8'
     description = 'Oh hi, this is a nice description for a project, right?'
     website = 'https://github.com/novoda/bintray-release'
 }
 ```
+(note, since 0.2.8, publish.version can also be supplied on the command line. [See here](https://github.com/novoda/bintray-release/pull/23))
 
 Finally, use the task `bintrayUpload` to publish (make sure you build the project first!):
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.7'
+        classpath 'com.novoda:bintray-release:0.2.8'
     }
 }
 ```
@@ -36,7 +36,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'bintray-release'
-    version = '0.2.7'
+    version = '0.2.8'
     description = 'Oh hi, this is a nice description for a project right?'
     website = 'https://github.com/novoda/bintray-release'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,3 @@
 allprojects {
-    version = "0.2.7"
+    version = "0.2.8"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,6 +30,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.6'
+        classpath 'com.novoda:bintray-release:0.2.7'
     }
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -32,7 +32,7 @@ class BintrayConfiguration {
 
                 licenses = extension.licences
                 version {
-                    name = extension.version
+                    name = getString(project, 'version', extension.version)
                 }
             }
         }

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -19,12 +19,13 @@ class ReleasePlugin implements Plugin<Project> {
 
     void attachArtifacts(Project project) {
         Artifacts artifacts = project.plugins.hasPlugin('com.android.library') ? new AndroidArtifacts() : new JavaArtifacts()
+        String projectVersion = getString(project, 'version', project.publish.version)
         project.publishing {
             publications {
                 maven(MavenPublication) {
                     groupId project.publish.groupId
                     artifactId project.publish.artifactId
-                    version project.publish.version
+                    version projectVersion
 
                     artifacts.all(project).each {
                         delegate.artifact it
@@ -40,6 +41,10 @@ class ReleasePlugin implements Plugin<Project> {
         project.afterEvaluate {
             new BintrayConfiguration(extension).configure(project)
         }
+    }
+
+    private String getString(Project project, String propertyName, String defaultValue) {
+        project.hasProperty(propertyName) ? project.getProperty(propertyName) : defaultValue
     }
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.0-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-all.zip


### PR DESCRIPTION
This PR adds the possibility to make publish.version optional and define the version of the release as a project property, e.g. in a gradle file
```gradle
allProjects {
  version "0.2.8"
}
```
or as a command line parameter 
```
./gradlew bintrayUpload -Pversion=0.2.8 
```