### PR TITLE
using proper bintray plugin version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
     compile gradleApi()
 }
 


### PR DESCRIPTION
This PR fixes the bintray plugin version. Instead of version 1.1 we are using 1.0 now