### PR TITLE
27/Re-add support for publish.version 

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -43,11 +43,15 @@ class ReleasePlugin implements Plugin<Project> {
     }
 
     private String getProjectProperty(Project project, String propertyName, String defaultValue) {
-        if (project.hasProperty(propertyName) && project.getProperty(propertyName) != 'unspecified') {
+        if (isPropertySet(project, propertyName)) {
             return project.getProperty(propertyName)
         } else {
             return defaultValue
         }
+    }
+
+    private boolean isPropertySet(Project project, String propertyName) {
+        project.hasProperty(propertyName) && project.getProperty(propertyName) != 'unspecified'
     }
 
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -19,13 +19,12 @@ class ReleasePlugin implements Plugin<Project> {
 
     void attachArtifacts(Project project) {
         Artifacts artifacts = project.plugins.hasPlugin('com.android.library') ? new AndroidArtifacts() : new JavaArtifacts()
-        String projectVersion = getString(project, 'version', project.publish.version)
         project.publishing {
             publications {
                 maven(MavenPublication) {
                     groupId project.publish.groupId
                     artifactId project.publish.artifactId
-                    version projectVersion
+                    version getProjectProperty(project, 'version', project.publish.version)
 
                     artifacts.all(project).each {
                         delegate.artifact it
@@ -43,8 +42,12 @@ class ReleasePlugin implements Plugin<Project> {
         }
     }
 
-    private String getString(Project project, String propertyName, String defaultValue) {
-        project.hasProperty(propertyName) ? project.getProperty(propertyName) : defaultValue
+    private String getProjectProperty(Project project, String propertyName, String defaultValue) {
+        if (project.hasProperty(propertyName) && project.getProperty(propertyName) != 'unspecified') {
+            return project.getProperty(propertyName)
+        } else {
+            return defaultValue
+        }
     }
 
 }


### PR DESCRIPTION
**Problem**
Release 2.8 added support for project property "version". If this property was not set version "unspecified" was used instead of publish.version.

**Solution**
Check for "unspecified" when retrieving the property

**local maven for bintray-release**
![screen shot 2015-04-02 at 13 37 59](https://cloud.githubusercontent.com/assets/1449049/6963283/8a386332-d93d-11e4-9006-f0d8f548a01b.png)