### PR TITLE
#31 Wrong dependencies pulled into the pom

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidLibrary.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidLibrary.groovy
@@ -14,7 +14,7 @@ class AndroidLibrary implements SoftwareComponentInternal {
     private final Usage runtimeUsage
 
     public static AndroidLibrary newInstance(Project project) {
-        def configuration = project.configurations.getAll().find { it.dependencies }
+        def configuration = project.configurations.getByName("compile")
         return configuration ? from(configuration) : empty()
     }
 


### PR DESCRIPTION
Problem - When using `androidTestCompile` (or any other configuration alphabetically before compile) the compile dependencies are not picked up by the plugin

Why? 

Previously we were using 
```groovy
public static AndroidLibrary newInstance(Project project) {
    def configuration = project.configurations.getAll().find { it.dependencies }
    return configuration ? from(configuration) : empty()
}
```
which meant as soon as a configuration with dependencies was found we returned it eg `androidTestCompile`

Solution -
Forcing the compile configuration, I don't think we can have flavours with a library so we should be ok to do this :+1:  

Configuration list for ref -
```
!!!!! configuration ':core:_debugAndroidTestCompile'
!!!!! []
!!!!! configuration ':core:_debugAndroidTestPublish'
!!!!! []
!!!!! configuration ':core:_debugCompile'
!!!!! []
!!!!! configuration ':core:_debugPublish'
!!!!! []
!!!!! configuration ':core:_debugUnitTestCompile'
!!!!! []
!!!!! configuration ':core:_debugUnitTestPublish'
!!!!! []
!!!!! configuration ':core:_releaseCompile'
!!!!! []
!!!!! configuration ':core:_releasePublish'
!!!!! []
!!!!! configuration ':core:_releaseUnitTestCompile'
!!!!! []
!!!!! configuration ':core:_releaseUnitTestPublish'
!!!!! []
!!!!! configuration ':core:androidJacocoAgent'
!!!!! []
!!!!! configuration ':core:androidJacocoAnt'
!!!!! []
!!!!! configuration ':core:androidTestCompile'
!!!!! [DefaultExternalModuleDependency{group='com.novoda', name='notils', version='2.2.11', configuration='default'}]
!!!!! configuration ':core:androidTestProvided'
!!!!! []
!!!!! configuration ':core:androidTestPublish'
!!!!! []
!!!!! configuration ':core:androidTestWearApp'
!!!!! []
!!!!! configuration ':core:archives'
!!!!! []
!!!!! configuration ':core:compile'
!!!!! [DefaultExternalModuleDependency{group='com.android.support', name='support-v4', version='22.0.0', configuration='default'}, DefaultExternalModuleDependency{group='com.novoda', name='notils', version='2.2.11', configuration='default'}]
!!!!! configuration ':core:debugCompile'
!!!!! []
!!!!! configuration ':core:debugProvided'
!!!!! []
!!!!! configuration ':core:debugPublish'
!!!!! []
!!!!! configuration ':core:debugWearApp'
!!!!! []
!!!!! configuration ':core:default'
!!!!! []
!!!!! configuration ':core:provided'
!!!!! []
!!!!! configuration ':core:publish'
!!!!! []
!!!!! configuration ':core:releaseCompile'
!!!!! []
!!!!! configuration ':core:releaseProvided'
!!!!! []
!!!!! configuration ':core:releasePublish'
!!!!! []
!!!!! configuration ':core:releaseWearApp'
!!!!! []
!!!!! configuration ':core:testCompile'
!!!!! []
!!!!! configuration ':core:testDebugCompile'
!!!!! []
!!!!! configuration ':core:testDebugProvided'
!!!!! []
!!!!! configuration ':core:testDebugPublish'
!!!!! []
!!!!! configuration ':core:testDebugWearApp'
!!!!! []
!!!!! configuration ':core:testProvided'
!!!!! []
!!!!! configuration ':core:testPublish'
!!!!! []
!!!!! configuration ':core:testReleaseCompile'
!!!!! []
!!!!! configuration ':core:testReleaseProvided'
!!!!! []
!!!!! configuration ':core:testReleasePublish'
!!!!! []
!!!!! configuration ':core:testReleaseWearApp'
!!!!! []
!!!!! configuration ':core:testWearApp'
!!!!! []
!!!!! configuration ':core:wearApp'
!!!!! []
```

For this dependency graph
```groovy
dependencies {
    compile 'com.android.support:support-v4:22.0.0'
    compile 'com.squareup.picasso:picasso:2.5.0'

    androidTestCompile 'com.novoda:notils:2.2.11'
}
```

Before
==
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.novoda</groupId>
  <artifactId>landing-strip</artifactId>
  <version>0.0.2</version>
  <packaging>aar</packaging>
  <dependencies>
    <dependency>
      <groupId>com.novoda</groupId>
      <artifactId>notils</artifactId>
      <version>2.2.11</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```

After
== 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.novoda</groupId>
  <artifactId>landing-strip</artifactId>
  <version>0.0.2</version>
  <packaging>aar</packaging>
  <dependencies>
    <dependency>
      <groupId>com.android.support</groupId>
      <artifactId>support-v4</artifactId>
      <version>22.0.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>com.squareup.picasso</groupId>
      <artifactId>picasso</artifactId>
      <version>2.5.0</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```