### PR TITLE
adding android libraries classpath to the javadoc classpath

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -17,6 +17,8 @@ class AndroidArtifacts implements Artifacts {
         def androidJavadocs = project.task('androidJavadocs', type: Javadoc) {
             source = project.android.sourceSets.main.java.srcDirs
             classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
+            classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+            classpath += project.android.libraryVariants.toList().first().javaCompile.outputs.files
         }
 
         project.task('androidJavadocsJar', type: Jar, dependsOn: androidJavadocs) {


### PR DESCRIPTION
Fixes #21 #25 #38  

This doesn't handle variants but libraries can't have them soooooo we should be okay :+1: 