### PR TITLE
Preparing for release 0.2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.9'
+        classpath 'com.novoda:bintray-release:0.2.10'
     }
 }
 ```
@@ -36,7 +36,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'bintray-release'
-    version = '0.2.9'
+    version = '0.2.10'
     description = 'Oh hi, this is a nice description for a project, right?'
     website = 'https://github.com/novoda/bintray-release'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,3 @@
 allprojects {
-    version = "0.2.9"
+    version = "0.2.10"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,6 +30,6 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.7'
+        classpath 'com.novoda:bintray-release:0.2.9'
     }
 }


### PR DESCRIPTION
Getting ready to release 0.2.10 

- #21 fixes missing android libraries (.aar) from the javadoc classpath 