### PR TITLE
applying the publication name to the task creation

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -6,22 +6,26 @@ import org.gradle.api.tasks.javadoc.Javadoc
 
 class AndroidArtifacts implements Artifacts {
 
-    def sourcesJar(Project project) {
-        project.task('androidSourcesJar', type: Jar) {
+    def all(String publicationName, Project project) {
+        [sourcesJar(publicationName, project), javadocJar(publicationName, project), mainJar(project)]
+    }
+
+    def sourcesJar(String publicationName, Project project) {
+        project.task(publicationName + 'AndroidSourcesJar', type: Jar) {
             classifier = 'sources'
             from project.android.sourceSets.main.java.srcDirs
         }
     }
 
-    def javadocJar(Project project) {
-        def androidJavadocs = project.task('androidJavadocs', type: Javadoc) {
+    def javadocJar(String publicationName, Project project) {
+        def androidJavadocs = project.task(publicationName + 'AndroidJavadocs', type: Javadoc) {
             source = project.android.sourceSets.main.java.srcDirs
             classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
             classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
             classpath += project.android.libraryVariants.toList().first().javaCompile.outputs.files
         }
 
-        project.task('androidJavadocsJar', type: Jar, dependsOn: androidJavadocs) {
+        project.task(publicationName + 'AndroidJavadocsJar', type: Jar, dependsOn: androidJavadocs) {
             classifier = 'javadoc'
             from androidJavadocs.destinationDir
         }
@@ -36,7 +40,4 @@ class AndroidArtifacts implements Artifacts {
         project.components.android
     }
 
-    def all(Project project) {
-        [sourcesJar(project), javadocJar(project), mainJar(project)]
-    }
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
@@ -4,6 +4,6 @@ import org.gradle.api.Project
 
 interface Artifacts {
 
-    def all(Project project)
+    def all(String publicationName, Project project)
 
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
@@ -5,15 +5,19 @@ import org.gradle.api.tasks.bundling.Jar
 
 class JavaArtifacts implements Artifacts {
 
-    def sourcesJar(Project project) {
-        project.task('sourcesJar', type: Jar) {
+    def all(String publicationName, Project project) {
+        [sourcesJar(publicationName, project), javadocJar(publicationName, project)]
+    }
+
+    def sourcesJar(String publicationName, Project project) {
+        project.task(publicationName + 'SourcesJar', type: Jar) {
             classifier = 'sources'
             from project.sourceSets.main.allSource
         }
     }
 
-    def javadocJar(Project project) {
-        project.task('javadocJar', type: Jar) {
+    def javadocJar(String publicationName, Project project) {
+        project.task(publicationName + 'JavadocJar', type: Jar) {
             classifier = 'javadoc'
             from project.javadoc.destinationDir
         }
@@ -23,8 +27,4 @@ class JavaArtifacts implements Artifacts {
         project.components.java
     }
 
-
-    def all(Project project) {
-        [sourcesJar(project), javadocJar(project)]
-    }
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -18,15 +18,17 @@ class ReleasePlugin implements Plugin<Project> {
     }
 
     void attachArtifacts(Project project) {
-        Artifacts artifacts = project.plugins.hasPlugin('com.android.library') ? new AndroidArtifacts() : new JavaArtifacts()
         project.publishing {
             publications {
+                Artifacts artifacts = project.plugins.hasPlugin('com.android.library') ? new AndroidArtifacts() : new JavaArtifacts()
+
                 maven(MavenPublication) {
+
                     groupId project.publish.groupId
                     artifactId project.publish.artifactId
                     version getProjectProperty(project, 'version', project.publish.version)
 
-                    artifacts.all(project).each {
+                    artifacts.all(it.name, project).each {
                         delegate.artifact it
                     }
 


### PR DESCRIPTION
Fixes #41 

Adds the publication name to the artifact task creation, this will fix errors when providing custom publications 

![screen shot 2015-04-12 at 13 47 42](https://cloud.githubusercontent.com/assets/1848238/7105629/939c41a2-e11a-11e4-8e4f-da94ef2b6117.png)

This means you can now do this 

```groovy
publish {
    userOrg = 'novoda'
    groupId = 'com.novoda'
    artifactId = rootProject.name
    version = project.version

    description = 'Super duper easy way to release your Android and other artifacts to bintray'
    website = "https://github.com/novoda/${rootProject.name}"

    publishing {
        publications {
            superPublication(MavenPublication) {
                groupId project.publish.groupId
                artifactId project.publish.artifactId
                version project.publish.version

                Artifacts artifacts = new JavaArtifacts()

                artifacts.all(it.name, project).each {
                    delegate.artifact it
                }

                from artifacts.from(project)
            }
        }
    }

    publications =["superPublication"]

}
```

![screen shot 2015-04-12 at 13 58 02](https://cloud.githubusercontent.com/assets/1848238/7105669/009c9da0-e11c-11e4-8783-f259e7e614cf.png)
