### PR TITLE
Feature/Support for gradle plugins

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -1,8 +1,5 @@
 package com.novoda.gradle.release
-
 import org.gradle.api.Project
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileTree
 
 class BintrayConfiguration {
 
@@ -62,18 +59,11 @@ class BintrayConfiguration {
 
     private void deriveDefaultsFromProject(Project project) {
         if (extension.versionAttributes.isEmpty()) {
-            FileTree pluginFiles = project.fileTree(dir: 'src/main/resources/META-INF/gradle-plugins')
-            if (!pluginFiles.isEmpty()) {
-                FileCollection filteredPluginFiles  = pluginFiles.filter {
-                    it.name.endsWith(".properties") &&
-                            it.name.substring(0, it.name.length() - 11).contains('.')
-                }
-                if (!filteredPluginFiles.isEmpty()) {
-                    File bestPluginFile = filteredPluginFiles.first()
-                    String pluginId = bestPluginFile.name.substring(0, bestPluginFile.name.length() - 11)
-                    extension.versionAttributes << ['gradle-plugins': "$pluginId:$extension.groupId:$extension.artifactId"]
-                    println "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
-                }
+            def gradlePluginPropertyFinder = new GradlePluginPropertyFinder(project)
+            String bestPluginId = gradlePluginPropertyFinder.findBestGradlePluginId()
+            if (bestPluginId != null) {
+                extension.versionAttributes << ['gradle-plugins': "$bestPluginId:$extension.groupId:$extension.artifactId"]
+                println "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
             }
         }
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -12,6 +12,7 @@ class BintrayConfiguration {
 
     void configure(Project project) {
         initDefaults()
+        deriveDefaultsFromProject(project)
 
         PropertyFinder propertyFinder = new PropertyFinder(project, extension)
 
@@ -35,10 +36,10 @@ class BintrayConfiguration {
                 licenses = extension.licences
                 version {
                     name = propertyFinder.getPublishVersion()
+                    attributes = extension.versionAttributes
                 }
             }
         }
-
         project.tasks.bintrayUpload.mustRunAfter(project.tasks.uploadArchives)
     }
 
@@ -57,4 +58,9 @@ class BintrayConfiguration {
         }
     }
 
+    private void deriveDefaultsFromProject(Project project) {
+        if (!project.fileTree(dir: 'src/main/resources/META-INF/gradle-plugins').isEmpty()) {
+            extension.versionAttributes << ['gradle-plugins': '${extension.userOrg}:${extension.groupId}:${extension.artifactId}']
+        }
+    }
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -1,6 +1,7 @@
 package com.novoda.gradle.release
 
 import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 
 class BintrayConfiguration {
@@ -63,14 +64,17 @@ class BintrayConfiguration {
         if (extension.versionAttributes.isEmpty()) {
             FileTree pluginFiles = project.fileTree(dir: 'src/main/resources/META-INF/gradle-plugins')
             if (!pluginFiles.isEmpty()) {
-                File bestPluginFile = pluginFiles.filter {
+                FileCollection filteredPluginFiles  = pluginFiles.filter {
                     it.name.endsWith(".properties") &&
                             it.name.substring(0, it.name.length() - 11).contains('.')
-                }.first()
-                String pluginId = bestPluginFile.name.substring(0, bestPluginFile.name.length() - 11)
-                extension.versionAttributes << ['gradle-plugins': "$pluginId:$extension.groupId:$extension.artifactId"]
+                }
+                if (!filteredPluginFiles.isEmpty()) {
+                    File bestPluginFile = filteredPluginFiles.first()
+                    String pluginId = bestPluginFile.name.substring(0, bestPluginFile.name.length() - 11)
+                    extension.versionAttributes << ['gradle-plugins': "$pluginId:$extension.groupId:$extension.artifactId"]
+                    println "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
+                }
             }
-            println "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
         }
     }
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -1,6 +1,7 @@
 package com.novoda.gradle.release
 
 import org.gradle.api.Project
+import org.gradle.api.file.FileTree
 
 class BintrayConfiguration {
 
@@ -59,8 +60,17 @@ class BintrayConfiguration {
     }
 
     private void deriveDefaultsFromProject(Project project) {
-        if (!project.fileTree(dir: 'src/main/resources/META-INF/gradle-plugins').isEmpty()) {
-            extension.versionAttributes << ['gradle-plugins': '${extension.userOrg}:${extension.groupId}:${extension.artifactId}']
+        if (extension.versionAttributes.isEmpty()) {
+            FileTree pluginFiles = project.fileTree(dir: 'src/main/resources/META-INF/gradle-plugins')
+            if (!pluginFiles.isEmpty()) {
+                File bestPluginFile = pluginFiles.filter {
+                    it.name.endsWith(".properties") &&
+                            it.name.substring(0, it.name.length() - 11).contains('.')
+                }.first()
+                String pluginId = bestPluginFile.name.substring(0, bestPluginFile.name.length() - 11)
+                extension.versionAttributes << ['gradle-plugins': "$pluginId:$extension.groupId:$extension.artifactId"]
+            }
+            println "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
         }
     }
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/GradlePluginPropertyFinder.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/GradlePluginPropertyFinder.groovy
@@ -1,0 +1,37 @@
+package com.novoda.gradle.release
+
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
+
+class GradlePluginPropertyFinder {
+    private static final String FILE_EXTENSION_PROPERTIES = ".properties"
+    private final Project project
+
+    GradlePluginPropertyFinder(Project project) {
+        this.project = project
+    }
+
+    public String findBestGradlePluginId() {
+        FileTree pluginFiles = project.fileTree(dir:'src/main/resources/META-INF/gradle-plugins')
+        if (!pluginFiles.isEmpty()) {
+            FileCollection filteredPluginFiles = pluginFiles.filter {
+                it.name.endsWith(FILE_EXTENSION_PROPERTIES) &&
+                        isNamespacedPropertyFile(it)
+            }
+            if (!filteredPluginFiles.isEmpty()) {
+                File bestPluginFile = filteredPluginFiles.first()
+                return removePropertyFileExtension(bestPluginFile)
+            }
+        }
+        return null;
+    }
+
+    private boolean isNamespacedPropertyFile(File file) {
+        return file.name.substring(0, file.name.length() - FILE_EXTENSION_PROPERTIES.length()).contains('.')
+    }
+
+    private String removePropertyFileExtension(File bestPluginFile) {
+        bestPluginFile.name.substring(0, bestPluginFile.name.length() - FILE_EXTENSION_PROPERTIES.length())
+    }
+}

--- a/core/src/main/groovy/com/novoda/gradle/release/GradlePluginPropertyFinder.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/GradlePluginPropertyFinder.groovy
@@ -13,18 +13,19 @@ class GradlePluginPropertyFinder {
     }
 
     public String findBestGradlePluginId() {
-        FileTree pluginFiles = project.fileTree(dir:'src/main/resources/META-INF/gradle-plugins')
-        if (!pluginFiles.isEmpty()) {
-            FileCollection filteredPluginFiles = pluginFiles.filter {
-                it.name.endsWith(FILE_EXTENSION_PROPERTIES) &&
-                        isNamespacedPropertyFile(it)
-            }
-            if (!filteredPluginFiles.isEmpty()) {
-                File bestPluginFile = filteredPluginFiles.first()
-                return removePropertyFileExtension(bestPluginFile)
-            }
+        FileTree pluginFiles = project.fileTree(dir: 'src/main/resources/META-INF/gradle-plugins')
+        if (pluginFiles.isEmpty()) {
+            return null
         }
-        return null;
+        FileCollection filteredPluginFiles = pluginFiles.filter {
+            it.name.endsWith(FILE_EXTENSION_PROPERTIES) &&
+                    isNamespacedPropertyFile(it)
+        }
+        if (filteredPluginFiles.isEmpty()) {
+            return null
+        }
+        File bestPluginFile = filteredPluginFiles.first()
+        return removePropertyFileExtension(bestPluginFile)
     }
 
     private boolean isNamespacedPropertyFile(File file) {

--- a/core/src/main/groovy/com/novoda/gradle/release/PublishExtension.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/PublishExtension.groovy
@@ -16,6 +16,8 @@ class PublishExtension {
     String version
     String publishVersion;
 
+    Map<String, String> versionAttributes = [:]
+
     String[] licences = ['Apache-2.0']
 
     String uploadName = ''


### PR DESCRIPTION
This PR adds versionAttribute property that is used for publishing gradle plugins at the gradle plugin portal.

The default value is an empty map.

For gradle plugins, the value is set similar to the [plugindev plugin](
https://github.com/etiennestuder/gradle-plugindev-plugin/blob/master/src/main/groovy/nu/studer/gradle/plugindev/PluginDevPlugin.groovy#L291) based on the first property file that uses a namespaced plugin id.