### PR TITLE
61/Fix versionAttributes key for gradle portal

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -62,7 +62,7 @@ class BintrayConfiguration {
             def gradlePluginPropertyFinder = new GradlePluginPropertyFinder(project)
             String bestPluginId = gradlePluginPropertyFinder.findBestGradlePluginId()
             if (bestPluginId != null) {
-                extension.versionAttributes << ['gradle-plugins': "$bestPluginId:$extension.groupId:$extension.artifactId"]
+                extension.versionAttributes << ['gradle-plugin': "$bestPluginId:$extension.groupId:$extension.artifactId"]
                 println "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
             }
         }

--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -1,4 +1,5 @@
 package com.novoda.gradle.release
+
 import org.gradle.api.Project
 
 class BintrayConfiguration {
@@ -63,7 +64,7 @@ class BintrayConfiguration {
             String bestPluginId = gradlePluginPropertyFinder.findBestGradlePluginId()
             if (bestPluginId != null) {
                 extension.versionAttributes << ['gradle-plugin': "$bestPluginId:$extension.groupId:$extension.artifactId"]
-                println "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
+                project.logger.info "Using plugin identifier '" + extension.versionAttributes.get('gradle-plugins') + "' for gradle portal."
             }
         }
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/GradlePluginPropertyFinder.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/GradlePluginPropertyFinder.groovy
@@ -12,7 +12,7 @@ class GradlePluginPropertyFinder {
         this.project = project
     }
 
-    public String findBestGradlePluginId() {
+    String findBestGradlePluginId() {
         FileTree pluginFiles = project.fileTree(dir: 'src/main/resources/META-INF/gradle-plugins')
         if (pluginFiles.isEmpty()) {
             return null


### PR DESCRIPTION
This PR fixes #61 by removing on character.

It also adds using logger instead of println and removes unncessary public keyword.