### PR TITLE
Support multiflavor libraries in Android projects

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -22,7 +22,7 @@ class BintrayConfiguration {
             publish = extension.autoPublish
             dryRun = propertyFinder.getDryRun()
 
-            publications = extension.publications
+            publications = extension.publications ?: project.plugins.hasPlugin('com.android.library') ? project.android.libraryVariants.collect { it.name } : [ 'maven' ]
 
             pkg {
                 repo = extension.repoName

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -25,7 +25,7 @@ class ReleasePlugin implements Plugin<Project> {
                     if (variant.productFlavors.size() > 0) {
                         artifactId += '-' + variant.productFlavors.collect { it.name }.join("-")
                     }
-                    addArtifact(project, variant.name, artifactId, new AndroidArtifacts());
+                    addArtifact(project, variant.name, artifactId, new AndroidArtifacts(variant));
                 }
             }
         } else {

--- a/core/src/test/groovy/com/novoda/gradle/release/LibProjectFactory.groovy
+++ b/core/src/test/groovy/com/novoda/gradle/release/LibProjectFactory.groovy
@@ -24,4 +24,30 @@ final class LibProjectFactory {
 
         return project
     }
+
+    public static Project createFromFixtureWithFlavors() {
+        Project project = ProjectBuilder.builder().withProjectDir(new File(TestConfiguration.FIXTURE_WORKING_DIR)).build()
+        project.apply plugin: 'com.android.library'
+        project.version = "1.0"
+        project.group = "com.novoda.demo.gradle.release"
+        project.android {
+            compileSdkVersion 23
+            buildToolsVersion '23.0.0'
+
+            defaultConfig {
+                versionCode 1
+                versionName '1.0'
+                minSdkVersion 23
+                targetSdkVersion 23
+            }
+
+            productFlavors {
+                flavor1{}
+                flavor2{}
+            }
+        }
+
+        return project
+
+    }
 }


### PR DESCRIPTION
**The Problem**
Before the plugin would not work if productFlavors were used in a library. 
**The Solution**
By adding publications for every [libraryVariant](http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Multi-flavor-variants) (which is non-debugable) and collecting the sources/javadoc for all sourceSets in those libraryVariants.