### PR TITLE
Add flavor and buildType specific dependencies to pom

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -46,8 +46,7 @@ class AndroidArtifacts implements Artifacts {
     }
 
     def from(Project project) {
-        project.components.add(AndroidLibrary.newInstance(project))
-        project.components.android
+        AndroidLibrary.newInstance(project, variant)
     }
 
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidLibrary.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidLibrary.groovy
@@ -13,13 +13,23 @@ class AndroidLibrary implements SoftwareComponentInternal {
 
     private final Usage runtimeUsage
 
-    public static AndroidLibrary newInstance(Project project) {
+    public static AndroidLibrary newInstance(Project project, variant) {
+        DefaultDomainObjectSet<Dependency> dependencies = new DefaultDomainObjectSet<Dependency>(Dependency)
         def configuration = project.configurations.getByName("compile")
-        return configuration ? from(configuration) : empty()
+        if (configuration != null) dependencies.addAll(configuration.dependencies);
+        variant.productFlavors.each { flavor ->
+            configuration = project.configurations.getByName(flavor.name+"Compile")
+            if (configuration != null)
+                dependencies.addAll(configuration.dependencies)
+        }
+        configuration = project.configurations.getByName(variant.buildType.name+"Compile")
+        if (configuration != null)
+            dependencies.addAll(configuration.dependencies)
+        return configuration ? from(dependencies) : empty()
     }
 
-    static AndroidLibrary from(def configuration) {
-        def usage = new RuntimeUsage(configuration.dependencies)
+    static AndroidLibrary from(dependencies) {
+        def usage = new RuntimeUsage(dependencies)
         new AndroidLibrary(usage)
     }
 

--- a/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
@@ -6,4 +6,5 @@ interface Artifacts {
 
     def all(String publicationName, Project project)
 
+    def from(Project project)
 }

--- a/core/src/test/groovy/com/novoda/gradle/release/LibProjectFactory.groovy
+++ b/core/src/test/groovy/com/novoda/gradle/release/LibProjectFactory.groovy
@@ -22,6 +22,15 @@ final class LibProjectFactory {
             }
         }
 
+        project.repositories {
+            jcenter()
+        }
+
+        project.dependencies {
+            compile 'com.novoda:download-manager:0.2.38'
+            releaseCompile 'com.google.code.gson:gson:2.5'
+        }
+
         return project
     }
 
@@ -45,6 +54,16 @@ final class LibProjectFactory {
                 flavor1{}
                 flavor2{}
             }
+        }
+
+        project.repositories {
+            jcenter()
+        }
+
+        project.dependencies {
+            compile 'com.novoda:download-manager:0.2.38'
+            flavor1Compile 'com.google.code.gson:gson:2.5'
+
         }
 
         return project


### PR DESCRIPTION
**The Problem**
In my previous PR I added support for publishing multi-flavor libraries. When I wanted to use it I had missing transitive dependencies in the generated pom. This was because only 'compile' configuration dependencies were added

**The solution**
By making a AndroidLibrary determine dependencies based on flavors the debugCompile and flavorCompile dependencies are also added to the pom
