### PR TITLE
Changed the SO tag to `bintray`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Here are a list of useful links:
  * We always welcome people to contribute new features or bug fixes, [here is how](https://github.com/novoda/novoda/blob/master/CONTRIBUTING.md)
  * If you have a problem check the [Issues Page](https://github.com/novoda/bintray-release/issues) first to see if we are working on it
  * For further usage or to delve more deeply checkout the [Project Wiki](https://github.com/novoda/bintray-release/wiki)
- * Looking for community help, browse the already asked [Stack Overflow Questions](http://stackoverflow.com/questions/tagged/support-bintray-release) or use the tag: `support-bintray-release` when posting a new question  
+ * Looking for community help, browse the already asked [Stack Overflow Questions](http://stackoverflow.com/questions/tagged/support-bintray-release) or use the tag: `bintray` when posting a new question  


### PR DESCRIPTION
Hey, we are trying to prevent the proliferation of Bintray related tags on SO. I understand that you want to set up an alert on a very specific tag to isolate the noise, but `[bintray]` is relatively inactive ATM, so you wan't get much spam, and as a side effect you'll be able to suggest your great plugin for people asking questions about Bintray.
Thanks for the understanding!
