### PR TITLE
Support 'override' param

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -21,6 +21,7 @@ class BintrayConfiguration {
             key = propertyFinder.getBintrayKey()
             publish = extension.autoPublish
             dryRun = propertyFinder.getDryRun()
+            override = propertyFinder.getOverride()
 
             publications = extension.publications ?: project.plugins.hasPlugin('com.android.library') ? ['release'] : [ 'maven' ]
 

--- a/core/src/main/groovy/com/novoda/gradle/release/PropertyFinder.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/PropertyFinder.groovy
@@ -24,6 +24,10 @@ class PropertyFinder {
         getBoolean(project, 'dryRun', extension.dryRun)
     }
 
+    def getOverride() {
+        getBoolean(project, 'override', extension.override)
+    }
+
     def getPublishVersion() {
         getString(project, 'publishVersion', extension.publishVersion ?: extension.version)
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/PublishExtension.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/PublishExtension.groovy
@@ -38,6 +38,7 @@ class PublishExtension {
     String bintrayUser = ''
     String bintrayKey = ''
     boolean dryRun = true
+    boolean override = false
 
     String[] publications
 


### PR DESCRIPTION
closes #104 

I created a [fork of bintray-release](https://github.com/YusukeIwaki/bintray-release) just for using `-Poverride=true` in my private project, and found it works well as expected.

Could you add this feature if you like?
