### PR TITLE
Fix asynchronously added variants

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -42,7 +42,7 @@ class ReleasePlugin implements Plugin<Project> {
                         """.stripMargin());
                 return;
             }
-            project.android.libraryVariants.each { variant ->
+            project.android.libraryVariants.all { variant ->
                 def artifactId = extension.artifactId;
                 addArtifact(project, variant.name, artifactId, new AndroidArtifacts(variant))
             }


### PR DESCRIPTION
`all` should be used because variants may not be available at that time when `.forEach` is call. `all` will also be called for each variant which will added later. This means here is a race condition on some machines not adding the required tasks.

see https://github.com/StefMa/AndroidArtifacts/pull/9

From the documentation:
https://docs.gradle.org/current/javadoc/org/gradle/api/DomainObjectCollection.html#all(groovy.lang.Closure)
Executes the given action against all objects in this collection, and any objects subsequently added to this collection.

"subsequently added" variants where ignored until now.

fixes  #96