### PR TITLE
gradle clean up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,0 @@
-
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
-    version = "0.8.0"
-}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -38,7 +38,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = rootProject.name
-    version = "0.8.0"
+    version = '0.8.0'
     description = 'Super duper easy way to release your Android and other artifacts to bintray'
     website = "https://github.com/novoda/${rootProject.name}"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.novoda.bintray-release' version "0.6.0"
+    id 'com.novoda.bintray-release' version "0.8.0"
     id 'groovy'
     id 'java-gradle-plugin'
     id 'maven'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,15 +1,8 @@
-apply plugin: 'com.novoda.bintray-release'
-apply plugin: 'groovy'
-apply plugin: 'java-gradle-plugin'
-apply plugin: 'maven'
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.novoda:bintray-release:0.6.0'
-    }
+plugins {
+    id 'com.novoda.bintray-release' version "0.6.0"
+    id 'groovy'
+    id 'java-gradle-plugin'
+    id 'maven'
 }
 
 repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,16 +6,13 @@ apply plugin: 'maven'
 buildscript {
     repositories {
         jcenter()
-        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.novoda:bintray-release:0.6.0'
     }
 }
 
 repositories {
-    google()
     jcenter()
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,6 +31,19 @@ compileGroovy {
     targetCompatibility = '1.6'
 }
 
+gradlePlugin {
+    plugins {
+        binrayRelease {
+            id = "com.novoda.bintray-release"
+            implementationClass = "com.novoda.gradle.release.ReleasePlugin"
+        }
+        legacy {
+            id = "bintray-release"
+            implementationClass = "com.novoda.gradle.release.ReleasePlugin"
+        }
+    }
+}
+
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -37,7 +37,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = rootProject.name
-    version = project.version
+    version = "0.8.0"
     description = 'Super duper easy way to release your Android and other artifacts to bintray'
     website = "https://github.com/novoda/${rootProject.name}"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,11 +20,9 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
     compile localGroovy()
     compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
 
-    testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'
 }
 

--- a/core/src/main/resources/META-INF/gradle-plugins/bintray-release.properties
+++ b/core/src/main/resources/META-INF/gradle-plugins/bintray-release.properties
@@ -1,1 +1,0 @@
-implementation-class=com.novoda.gradle.release.ReleasePlugin

--- a/core/src/main/resources/META-INF/gradle-plugins/com.novoda.bintray-release.properties
+++ b/core/src/main/resources/META-INF/gradle-plugins/com.novoda.bintray-release.properties
@@ -1,1 +1,0 @@
-implementation-class=com.novoda.gradle.release.ReleasePlugin

--- a/core/src/test/groovy/com/novoda/gradle/release/TestBintrayUploadTask.groovy
+++ b/core/src/test/groovy/com/novoda/gradle/release/TestBintrayUploadTask.groovy
@@ -28,6 +28,7 @@ public class TestBintrayUploadTask {
 
         GradleRunner runner = GradleRunner.create()
                 .withProjectDir(file)
+                .withPluginClasspath()
 
         if (arguments) {
             runner.withArguments(arguments)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        // TODO: Update later to gradlePluginPortal() if gradle updated
+        maven { url 'https://plugins.gradle.org/m2/' }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.novoda.bintray-release") {
+                useModule("com.novoda:bintray-release:${requested.version}")
+            }
+        }
+    }
+}
+
 include ':core'
 rootProject.name = 'bintray-release'


### PR DESCRIPTION
This is just some gradle "clean up"

* Remove the buildscript{} block completely and replace with the newer plugins{} block
* Remove the google() repo and dependencies because we don't use it
* Update the bintray plugin to the latest version 0.8.0
* Cleared the top-level `build.gradle` because we don't need it for now...

I've tested it by pushing the version to mavenLocal() and used this version to publish a new version of ThirtyInch. Works without any issues. See https://dl.bintray.com/stefma/maven/net/grandcentrix/thirtyinch/ and search for the version `0.8.6-gradlecleanup/`.
I've also used that version in a current project without any issues 👍 