### PR TITLE
Ci shell script

### DIFF
--- a/ci/prBuilder.sh
+++ b/ci/prBuilder.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+BASEDIR=$(dirname "$0")
+
+# Testing the core plugin
+cd $BASEDIR/../ && ./gradlew clean build bintrayUpload -PdryRun=true --info
+
+# Testing the samples
+cd $BASEDIR/samples/ && ./gradlew clean build bintrayUpload -PdryRun=true --info

--- a/samples/jvm/build.gradle
+++ b/samples/jvm/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'java-library'
 apply plugin: com.novoda.gradle.release.ReleasePlugin
 
+dependencies {
+    implementation "junit:junit:4.12"
+}
+
 publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'


### PR DESCRIPTION
This will introduce a shell script called `prBuilder`.
It should be run on jenkins side so that it get clear what jenkins will build 👍 

We have discussed that here https://github.com/novoda/bintray-release/issues/167#issuecomment-360269404

I've also added a dependency to the sample (makes no sense I know). But find out that dependencies are important thing to test...

Please change the Jenkins that it will run the ci script instead of "hardcoded" values... 👍 