### PR TITLE
Add gradle compatibility section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ $ ./gradlew clean build bintrayUpload -PbintrayUser=BINTRAY_USERNAME -PbintrayKe
 More info on the available properties and other usages in the [Github Wiki](https://github.com/novoda/bintray-release/wiki).
 
 ## Gradle compatibility
-| bintray-release version | Required Gradle version for | Notes                                        |
-|-------------------------|-----------------------------|----------------------------------------------|
-| 0.8.0                   | Java: 4.0 <br> Android: 4.1 | Gradle 4.5 doesn't work with Android libraries |
+| bintray-release version | Java Projects | Android Projects |
+|-------------------------|---------------|------------------|
+| 0.8.0                   | Gradle 4.0+   | Gradle 4.1+      |
+
+> **Notes: ** Currently Gradle 4.5 doesn't work with Android projects
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ More info on the available properties and other usages in the [Github Wiki](http
 |-------------------------|---------------|------------------|
 | 0.8.0                   | Gradle 4.0+   | Gradle 4.1+      |
 
-> **Notes: ** Currently Gradle 4.5 doesn't work with Android projects
+**Notes:** Currently Gradle 4.5 doesn't work with Android projects
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ More info on the available properties and other usages in the [Github Wiki](http
 |-------------------------|---------------|------------------|
 | 0.8.0                   | Gradle 4.0+   | Gradle 4.1+      |
 
-**Notes:** Currently Gradle 4.5 doesn't work with Android projects
+> **Notes:** Currently Gradle 4.5 doesn't work with Android projects
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Super duper easy way to release your Android and other artifacts to bintray.
 This is a helper for releasing libraries to bintray. It is intended to help configuring stuff related to maven and bintray.
 At the moment it works with Android Library projects, plain Java and plain Groovy projects, but our focus is to mainly support Android projects.
 
-> **Note:** At least **Gradle 4.0** is required!
-
 ## Adding to project
 
 To publish a library to bintray using this plugin, add these dependencies to the `build.gradle` of the module that will be published:
@@ -65,6 +63,10 @@ $ ./gradlew clean build bintrayUpload -PbintrayUser=BINTRAY_USERNAME -PbintrayKe
 
 More info on the available properties and other usages in the [Github Wiki](https://github.com/novoda/bintray-release/wiki).
 
+## Gradle compatibility
+| bintray-release version | Required Gradle version for | Notes                                        |
+|-------------------------|-----------------------------|----------------------------------------------|
+| 0.8.0                   | Java: 4.0 <br> Android: 4.1 | Gradle 4.5 doesn't work with Android libraries |
 
 ## Links
 


### PR DESCRIPTION
Just added a nicer table for Gradle compatibility to the readme...

<img width="940" alt="bildschirmfoto 2018-02-03 um 19 08 16" src="https://user-images.githubusercontent.com/10229883/35770110-a3808454-0915-11e8-9f4e-bb7f5acf4aca.png">
