### PR TITLE
give quicker feedback when setup incorrect

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -4,17 +4,45 @@ import com.jfrog.bintray.gradle.BintrayPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.util.GradleVersion
 
 class ReleasePlugin implements Plugin<Project> {
 
+    @Override
     void apply(Project project) {
         PublishExtension extension = project.extensions.create('publish', PublishExtension)
         project.afterEvaluate {
+            checkClosureSetup(extension)
             project.apply([plugin: 'maven-publish'])
             attachArtifacts(extension, project)
             new BintrayPlugin().apply(project)
             new BintrayConfiguration(extension).configure(project)
+        }
+    }
+
+    /**
+     * Give the user quicker and more obvious feedback when they
+     * haven't set their project up correctly
+     */
+    private static void checkClosureSetup(PublishExtension extension) {
+        String extensionError = "";
+        if (extension.userOrg == null) {
+            extensionError += "Missing userOrg. "
+        }
+        if (extension.groupId == null) {
+            extensionError += "Missing groupId. "
+        }
+        if (extension.artifactId == null) {
+            extensionError += "Missing artifactId. "
+        }
+        if (extension.publishVersion == null) {
+            extensionError += "Missing publishVersion. "
+        }
+        if (extension.desc == null) {
+            extensionError += "Missing desc. "
+        }
+        if (extensionError) {
+            String prefix = "Have you created the publish closure? "
+            throw new IllegalStateException(prefix + extensionError)
         }
     }
 


### PR DESCRIPTION
Was using on a pet project this weekend and wanted to sync once I added the dependency (but not written the closure yet). You get a cryptic error message like this:

![screen shot 2018-02-04 at 7 46 36 pm](https://user-images.githubusercontent.com/655860/35781677-099e8248-09e5-11e8-90f6-8a6b1640d91f.png)

So now if you don't have the closure, ie:

![screen shot 2018-02-04 at 7 46 49 pm](https://user-images.githubusercontent.com/655860/35781680-1f26bcac-09e5-11e8-97d4-91b37142bea4.png)

You get this error message:

![screen shot 2018-02-04 at 7 47 03 pm](https://user-images.githubusercontent.com/655860/35781682-274514ce-09e5-11e8-9051-5149cd4a3f83.png)

Also added a change of error message for each missing individual required field of the closure. 

ArtifactId missing:

![screen shot 2018-02-04 at 7 47 19 pm](https://user-images.githubusercontent.com/655860/35781693-40d3e064-09e5-11e8-9d06-847a8ff9b576.png)

gives:

![screen shot 2018-02-04 at 7 47 14 pm](https://user-images.githubusercontent.com/655860/35781703-4830857e-09e5-11e8-9ec6-b4f24e0823be.png)

_______

The readme says

> If you use Kotlin DSL use: (do something else)

I Have not tested this in a kotlin prj :-)