### PR TITLE
Exit script if command not exit with 0

### DIFF
--- a/ci/prBuilder.sh
+++ b/ci/prBuilder.sh
@@ -2,8 +2,16 @@
 
 BASEDIR=$(dirname "$0")
 
+function exitIfCommandFailed {
+    if [ $1 -ne 0 ]
+        then exit $1
+    fi
+}
+
 # Testing the core plugin
 cd $BASEDIR/../ && ./gradlew clean build bintrayUpload -PdryRun=true --info
+exitIfCommandFailed $?
 
 # Testing the samples
 cd $BASEDIR/../samples/ && ./gradlew clean build bintrayUpload -PdryRun=true --info
+exitIfCommandFailed $?

--- a/ci/prBuilder.sh
+++ b/ci/prBuilder.sh
@@ -1,17 +1,11 @@
 #!/bin/sh
 
-BASEDIR=$(dirname "$0")
+set -e
 
-function exitIfCommandFailed {
-    if [ $1 -ne 0 ]
-        then exit $1
-    fi
-}
+BASEDIR=$(dirname "$0")
 
 # Testing the core plugin
 cd $BASEDIR/../ && ./gradlew clean build bintrayUpload -PdryRun=true --info
-exitIfCommandFailed $?
 
 # Testing the samples
 cd $BASEDIR/../samples/ && ./gradlew clean build bintrayUpload -PdryRun=true --info
-exitIfCommandFailed $?


### PR DESCRIPTION
The issue I found here (https://github.com/novoda/bintray-release/pull/174#issuecomment-363467914) was not because we need a `GradleException` which I fist assumend.
It was because of our jenkins PR script.

To go back to some shell basics:
Each command exits with a code. The exit code `0` signals "Everything was fine".
In a shell script we have only ONE exit code. The exit code from the "last command".
In our case the build from the samples folder.
This build was successfully. Which signals jenkins "Everything is ok". Which is wrong!

With that PR I created a function which checks the output of each command and exit earlier if the command don't exit with a zero.

You can see that it works in this (https://github.com/novoda/bintray-release/pull/186/files) PR. 👍 
(See here the jenkins job: https://ci.novoda.com/job/bintray-release-prb/77/console)
