### PR TITLE
Cleanup cannot resolve

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -2,6 +2,7 @@ package com.novoda.gradle.release
 
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
 
@@ -54,7 +55,7 @@ class AndroidArtifacts implements Artifacts {
     }
 
     @Override
-    def from(Project project) {
+    SoftwareComponent from(Project project) {
         project.components.add(new AndroidLibrary(project))
         project.components.android
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -23,8 +23,7 @@ class AndroidArtifacts implements Artifacts {
     def sourcesJar(Project project) {
         String taskName = variant.name + 'AndroidSourcesJar'
         project.task(taskName, type: Jar) {
-            def jar = it as Jar
-            jar.classifier = 'sources'
+            (it as Jar).classifier = 'sources'
             variant.sourceSets.each {
                 from it.java.srcDirs
             }
@@ -34,10 +33,10 @@ class AndroidArtifacts implements Artifacts {
     def javadocJar(Project project) {
         String taskName = variant.name + 'AndroidJavadocs'
         Task androidJavadocs = project.task(taskName, type: Javadoc) {
-            def javadoc = it as Javadoc
             variant.sourceSets.each {
                 delegate.source it.java.srcDirs
             }
+            def javadoc = it as Javadoc
             javadoc.classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
             javadoc.classpath += variant.javaCompile.classpath
             javadoc.classpath += variant.javaCompile.outputs.files
@@ -45,8 +44,7 @@ class AndroidArtifacts implements Artifacts {
 
         String taskNameJar = variant.name + 'AndroidJavadocsJar'
         project.task(taskNameJar, type: Jar, dependsOn: androidJavadocs) {
-            def jar = it as Jar
-            jar.classifier = 'javadoc'
+            (it as Jar).classifier = 'javadoc'
             from androidJavadocs.destinationDir
         }
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -1,6 +1,7 @@
 package com.novoda.gradle.release
 
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
 
@@ -8,6 +9,8 @@ class AndroidArtifacts implements Artifacts {
 
     def variant
 
+    // TODO: Declare that variant is
+    // https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.LibraryExtension.html#com.android.build.gradle.LibraryExtension:libraryVariants
     AndroidArtifacts(variant) {
         this.variant = variant
     }
@@ -17,8 +20,10 @@ class AndroidArtifacts implements Artifacts {
     }
 
     def sourcesJar(Project project) {
-        project.task(variant.name + 'AndroidSourcesJar', type: Jar) {
-            classifier = 'sources'
+        String taskName = variant.name + 'AndroidSourcesJar'
+        project.task(taskName, type: Jar) {
+            def jar = it as Jar
+            jar.classifier = 'sources'
             variant.sourceSets.each {
                 from it.java.srcDirs
             }
@@ -26,17 +31,21 @@ class AndroidArtifacts implements Artifacts {
     }
 
     def javadocJar(Project project) {
-        def androidJavadocs = project.task(variant.name + 'AndroidJavadocs', type: Javadoc) {
+        String taskName = variant.name + 'AndroidJavadocs'
+        Task androidJavadocs = project.task(taskName, type: Javadoc) {
+            def javadoc = it as Javadoc
             variant.sourceSets.each {
                 delegate.source it.java.srcDirs
             }
-            classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
-            classpath += variant.javaCompile.classpath
-            classpath += variant.javaCompile.outputs.files
+            javadoc.classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
+            javadoc.classpath += variant.javaCompile.classpath
+            javadoc.classpath += variant.javaCompile.outputs.files
         }
 
-        project.task(variant.name + 'AndroidJavadocsJar', type: Jar, dependsOn: androidJavadocs) {
-            classifier = 'javadoc'
+        String taskNameJar = variant.name + 'AndroidJavadocsJar'
+        project.task(taskNameJar, type: Jar, dependsOn: androidJavadocs) {
+            def jar = it as Jar
+            jar.classifier = 'javadoc'
             from androidJavadocs.destinationDir
         }
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -15,6 +15,7 @@ class AndroidArtifacts implements Artifacts {
         this.variant = variant
     }
 
+    @Override
     def all(String publicationName, Project project) {
         [sourcesJar(project), javadocJar(project), mainJar(project)]
     }
@@ -54,6 +55,7 @@ class AndroidArtifacts implements Artifacts {
         "$project.buildDir/outputs/aar/${project.name}-${variant.baseName}.aar"
     }
 
+    @Override
     def from(Project project) {
         project.components.add(new AndroidLibrary(project))
         project.components.android

--- a/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
@@ -1,11 +1,12 @@
 package com.novoda.gradle.release;
 
 import org.gradle.api.Project
+import org.gradle.api.component.SoftwareComponent
 
 interface Artifacts {
 
     def all(String publicationName, Project project)
 
-    def from(Project project)
+    SoftwareComponent from(Project project)
 
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/Artifacts.groovy
@@ -6,4 +6,6 @@ interface Artifacts {
 
     def all(String publicationName, Project project)
 
+    def from(Project project)
+
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/BintrayConfiguration.groovy
@@ -1,5 +1,6 @@
 package com.novoda.gradle.release
 
+import com.jfrog.bintray.gradle.BintrayExtension
 import org.gradle.api.Project
 
 class BintrayConfiguration {
@@ -16,16 +17,17 @@ class BintrayConfiguration {
 
         PropertyFinder propertyFinder = new PropertyFinder(project, extension)
 
-        project.bintray {
+        def bintrayExtension = project.extensions.findByName("bintray") as BintrayExtension
+        bintrayExtension.with {
             user = propertyFinder.bintrayUser
             key = propertyFinder.bintrayKey
             publish = extension.autoPublish
             dryRun = propertyFinder.dryRun
             override = propertyFinder.override
 
-            publications = extension.publications ?: project.plugins.hasPlugin('com.android.library') ? ['release'] : [ 'maven' ]
+            publications = extension.publications ?: project.plugins.hasPlugin('com.android.library') ? ['release'] : ['maven']
 
-            pkg {
+            pkg.with {
                 repo = extension.repoName
                 userOrg = extension.userOrg
                 name = extension.uploadName
@@ -35,7 +37,7 @@ class BintrayConfiguration {
                 vcsUrl = extension.repository
 
                 licenses = extension.licences
-                version {
+                version.with {
                     name = propertyFinder.publishVersion
                     attributes = extension.versionAttributes
                 }

--- a/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
@@ -12,14 +12,14 @@ class JavaArtifacts implements Artifacts {
 
     def sourcesJar(String publicationName, Project project) {
         project.task(publicationName + 'SourcesJar', type: Jar) {
-            classifier = 'sources'
+            (it as Jar).classifier = 'sources'
             from project.sourceSets.main.allSource
         }
     }
 
     def javadocJar(String publicationName, Project project) {
         project.task(publicationName + 'JavadocJar', type: Jar) {
-            classifier = 'javadoc'
+            (it as Jar).classifier = 'javadoc'
             from project.javadoc.destinationDir
         }
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
@@ -1,6 +1,7 @@
 package com.novoda.gradle.release
 
 import org.gradle.api.Project
+import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.tasks.bundling.Jar
 
 class JavaArtifacts implements Artifacts {
@@ -25,7 +26,7 @@ class JavaArtifacts implements Artifacts {
     }
 
     @Override
-    def from(Project project) {
+    SoftwareComponent from(Project project) {
         project.components.java
     }
 

--- a/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/JavaArtifacts.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.tasks.bundling.Jar
 
 class JavaArtifacts implements Artifacts {
 
+    @Override
     def all(String publicationName, Project project) {
         [sourcesJar(publicationName, project), javadocJar(publicationName, project)]
     }
@@ -23,6 +24,7 @@ class JavaArtifacts implements Artifacts {
         }
     }
 
+    @Override
     def from(Project project) {
         project.components.java
     }

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -61,14 +61,15 @@ class ReleasePlugin implements Plugin<Project> {
     void addArtifact(Project project, String name, String artifact, Artifacts artifacts) {
         PropertyFinder propertyFinder = new PropertyFinder(project, project.publish)
         project.publishing.publications.create(name, MavenPublication) {
-            groupId project.publish.groupId
-            artifactId artifact
-            version = propertyFinder.publishVersion
+            def publication = it as MavenPublication
+            publication.groupId = project.publish.groupId
+            publication.artifactId = artifact
+            publication.version = propertyFinder.publishVersion
 
             artifacts.all(it.name, project).each {
                 delegate.artifact it
             }
-            from artifacts.from(project)
+            publication.from = artifacts.from(project)
         }
     }
 }

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -49,22 +49,20 @@ class ReleasePlugin implements Plugin<Project> {
     void attachArtifacts(PublishExtension extension, Project project) {
         if (project.plugins.hasPlugin('com.android.library')) {
             project.android.libraryVariants.all { variant ->
-                def artifactId = extension.artifactId;
-                addArtifact(project, variant.name, artifactId, new AndroidArtifacts(variant))
+                addArtifact(project, variant.name as String, extension, new AndroidArtifacts(variant))
             }
         } else {
-            addArtifact(project, 'maven', project.publish.artifactId, new JavaArtifacts())
+            addArtifact(project, 'maven', extension, new JavaArtifacts())
         }
     }
 
 
-    void addArtifact(Project project, String name, String artifact, Artifacts artifacts) {
-        PropertyFinder propertyFinder = new PropertyFinder(project, project.publish)
+    void addArtifact(Project project, String name, PublishExtension extension, Artifacts artifacts) {
         project.publishing.publications.create(name, MavenPublication) {
             def publication = it as MavenPublication
-            publication.groupId = project.publish.groupId
-            publication.artifactId = artifact
-            publication.version = propertyFinder.publishVersion
+            publication.groupId = extension.groupId
+            publication.artifactId = extension.artifactId
+            publication.version = new PropertyFinder(project, extension).publishVersion
 
             artifacts.all(it.name, project).each {
                 delegate.artifact it

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -67,7 +67,7 @@ class ReleasePlugin implements Plugin<Project> {
             artifacts.all(it.name, project).each {
                 delegate.artifact it
             }
-            publication.from = artifacts.from(project)
+            publication.from(artifacts.from(project))
         }
     }
 }


### PR DESCRIPTION
Cleanup the whole plugin a little bit 😅 
Everything startet with that:
<img width="242" alt="bildschirmfoto 2018-02-08 um 11 06 28" src="https://user-images.githubusercontent.com/10229883/35969533-76e01fbc-0cc7-11e8-8613-da8b9518a4f1.png">
For me it is so annoying that most of the properties cannot be resolved that I've make it better:
<img width="185" alt="bildschirmfoto 2018-02-08 um 11 06 34" src="https://user-images.githubusercontent.com/10229883/35969534-76fc94bc-0cc7-11e8-9604-7f3086574f22.png">

Everything is accessible and cleaner where it comes from and where we add it.

I've also changed the Artifact interface which have missed the `from()`  method. I've changed it to a `SoftwareComponent` because otherwise the `MavenPublication.from()` will complain that it don't know what it is. And that is what I basically want to avoid 😂 

I've also tested it and uploaded to my private bintreay account:
https://dl.bintray.com/stefma/maven/net/grandcentrix/thirtyinch/

Seems every files are up 👍 
But I haven't tested if the files are "correct". 