### PR TITLE
Add support for Android's archivesBaseName property

### DIFF
--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -42,7 +42,8 @@ class AndroidArtifacts implements Artifacts {
     }
 
     def mainJar(Project project) {
-        "$project.buildDir/outputs/aar/${project.name}-${variant.baseName}.aar"
+        def artifactBaseName = project.getProperty("archivesBaseName")
+        "$project.buildDir/outputs/aar/$artifactBaseName-${variant.baseName}.aar"
     }
 
     def from(Project project) {

--- a/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy
@@ -42,8 +42,8 @@ class AndroidArtifacts implements Artifacts {
     }
 
     def mainJar(Project project) {
-        def artifactBaseName = project.getProperty("archivesBaseName")
-        "$project.buildDir/outputs/aar/$artifactBaseName-${variant.baseName}.aar"
+        def archiveBaseName = project.hasProperty("archivesBaseName") ? project.getProperty("archivesBaseName") : project.name
+        "$project.buildDir/outputs/aar/$archiveBaseName-${variant.baseName}.aar"
     }
 
     def from(Project project) {

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -18,8 +18,7 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName "1.0.0"
-
-        setProperty("archivesBaseName", "$project.name-$versionName")
+        archivesBaseName = "$archivesBaseName-$versionName"
     }
 }
 

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -18,6 +18,8 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName "1.0.0"
+
+        setProperty("archivesBaseName", "$project.name-$versionName")
     }
 }
 


### PR DESCRIPTION
### Problem
In Android projects I like to include the version name in the resulting artifacts (e.g. `android-1.0.0-release.aar` instead of `android-release.aar`). Android supports setting a different archive name using the `archivesBaseName` property ([Android Gradle Pluggin support](https://stackoverflow.com/questions/18332474/how-to-set-versionname-in-apk-filename-using-gradle#28992851)).
```
setProperty("archivesBaseName", "${project.name}-$versionName")
```

So Android properly supports this, but the novoda bintray-release plugin doesn't. It always uses the `project.name` for the artifact name. So changing the `archivesBaseName` will cause the bintray-release upload to fail, since it can't find the artifact to upload.
```
> Failed to publish publication 'release' to repository 'mavenLocal'
   > Invalid publication 'release': artifact file does not exist: '/Users/myuser/mybuilddir/outputs/aar/android-release.aar'
```
### Solution
I've modified the [AndroidArtifacts.groovy](https://github.com/steurt/bintray-release/blob/08ea990f43562f7fb25a5259da46f02fe60650c0/core/src/main/groovy/com/novoda/gradle/release/AndroidArtifacts.groovy#L45#L46) to use the `archivesBaseName` property so it will always look for the correct artifact name. Whether it's modified or default: it's value is always set.

I've also modified the [build.gradle](https://github.com/steurt/bintray-release/blob/08ea990f43562f7fb25a5259da46f02fe60650c0/samples/android/build.gradle#L22) of the android samples project to demonstrate it's usage. Running a release for the android sample project also shows it works as desired.

### Update
It would be great if the (awesome 😎) novoda bintray-release plugin can support this! I hope you'll like this PR, include it in bintray-release and release it in an update soon so I can really start using it.

Any feedback is appreciated!