### PR TITLE
Remove wiki from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,4 @@ Here are a list of useful links:
 
  * We always welcome people to contribute new features or bug fixes, [here is how](https://github.com/novoda/novoda/blob/master/CONTRIBUTING.md)
  * If you have a problem check the [Issues Page](https://github.com/novoda/bintray-release/issues) first to see if we are working on it
- * For further usage or to delve more deeply checkout the [Project Wiki](https://github.com/novoda/bintray-release/wiki)
  * Looking for community help, browse the already asked [Stack Overflow Questions](http://stackoverflow.com/questions/tagged/support-bintray-release) or use the tag: `support-bintray-release` when posting a new question  


### PR DESCRIPTION
This will remove the wiki from the readme.
Its confusing to mention the wiki but don't provide one.
See #221 