### PR TITLE
Update internals

### DIFF
--- a/ci/prBuilder.sh
+++ b/ci/prBuilder.sh
@@ -5,7 +5,7 @@ set -e
 BASEDIR=$(dirname "$0")
 
 # Testing the core plugin
-cd $BASEDIR/../ && ./gradlew clean build bintrayUpload -PdryRun=true --info
+cd $BASEDIR/../ && ./gradlew clean build bintrayUpload -PdryRun=true -PbintrayUser=user -PbintrayKey=key --info
 
 # Testing the samples
-cd $BASEDIR/../samples/ && ./gradlew clean build bintrayUpload -PdryRun=true --info
+cd $BASEDIR/../samples/ && ./gradlew clean build bintrayUpload -PdryRun=true -PbintrayUser=user -PbintrayKey=key --info

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,7 +41,7 @@ buildProperties {
 
 dependencies {
     compile localGroovy()
-    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.9.0'

--- a/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -12,11 +12,11 @@ class ReleasePlugin implements Plugin<Project> {
         PublishExtension extension = project.extensions.create('publish', PublishExtension)
         project.afterEvaluate {
             extension.validate()
-            project.apply([plugin: 'maven-publish'])
             attachArtifacts(extension, project)
-            new BintrayPlugin().apply(project)
             new BintrayConfiguration(extension).configure(project)
         }
+        project.apply([plugin: 'maven-publish'])
+        new BintrayPlugin().apply(project)
     }
 
     void attachArtifacts(PublishExtension extension, Project project) {


### PR DESCRIPTION
A while back we have faced an [issue](https://github.com/novoda/bintray-release/issues/220) while trying to use this plugin to release a project using a recent version of Gradle (4.9+). After a quick look we thought the problem was on the [JFrog Gradle plugin]() that we apply under the hood, but further investigation has confirmed that the issue is not present in recent versions of that plugin (1.8.1+). I then decided to go ahead and make this plugin compile against a more recent version of the JFrog one, but while testing this implementation (using composite builds) I faced an interesting issue.

The recent implementation of the JFrog plugin is registering a custom [`BuildAdapter`](https://github.com/bintray/gradle-bintray-plugin/blob/1e801c71f78ff204f643d78253750590b919c37a/src/main/groovy/com/jfrog/bintray/gradle/ProjectsEvaluatedBuildListener.groovy#L35) to configure the upload tasks lazily, using the values collected in the extension after all the projects are fully configured and are ready to populate the task graph. Unfortunately we were applying that plugin after the [buildscript of the project is run](https://github.com/novoda/bintray-release/blob/0d998ad9cf4f822be2bcbffaf02bbee881f13101/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy#L13), and it seems at that point is too late for the JFrog plugin to register [its own build listener](https://github.com/bintray/gradle-bintray-plugin/blob/1e801c71f78ff204f643d78253750590b919c37a/src/main/groovy/com/jfrog/bintray/gradle/BintrayPlugin.groovy#L14), therefore the upload tasks were not including all the properties specified in the extension.

The fix is as easy as applying the JFrog plugin outside the `afterEvaluate {}`.