### PR TITLE
Issues/254: Fix typo in internal tasks name

### DIFF
--- a/plugin/core/src/main/groovy/com/novoda/gradle/release/MavenPublicationAttachments.groovy
+++ b/plugin/core/src/main/groovy/com/novoda/gradle/release/MavenPublicationAttachments.groovy
@@ -27,14 +27,14 @@ class MavenPublicationAttachments {
     }
 
     protected static Task sourcesJarTask(Project project, String publicationName, def ... sourcePaths) {
-        return project.task("genereateSourcesJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
+        return project.task("generateSourcesJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
             jar.classifier = 'sources'
             jar.from sourcePaths
         }
     }
 
     protected static Task javadocsJarTask(Project project, String publicationName, Javadoc javadoc) {
-        return project.task("genereateJavadocsJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
+        return project.task("generateJavadocsJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
             jar.classifier = 'javadoc'
             jar.from project.files(javadoc)
         }

--- a/plugin/core/src/test/groovy/com/novoda/gradle/release/ReleasePluginTest.groovy
+++ b/plugin/core/src/test/groovy/com/novoda/gradle/release/ReleasePluginTest.groovy
@@ -237,11 +237,11 @@ class ReleasePluginTest {
         }
 
         String getPackageJavadocsTaskName() {
-            return ":genereateJavadocsJarFor${publicationName.capitalize()}Publication"
+            return ":generateJavadocsJarFor${publicationName.capitalize()}Publication"
         }
 
         String getPackageSourcesTaskName() {
-            return ":genereateSourcesJarFor${publicationName.capitalize()}Publication"
+            return ":generateSourcesJarFor${publicationName.capitalize()}Publication"
         }
 
         String getPublishToMavenLocalTaskName() {


### PR DESCRIPTION
Fixes #254 

The name of the tasks generating the artifacts with sources and javadocs has a typo: `genereate*`-> `generate*`

Thanks @berberman for the heads-up! 🙌 