### PR TITLE
Add check if there is already a maven publication

### DIFF
--- a/plugin/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
+++ b/plugin/core/src/main/groovy/com/novoda/gradle/release/ReleasePlugin.groovy
@@ -32,9 +32,12 @@ class ReleasePlugin implements Plugin<Project> {
             }
         }
         project.plugins.withId('java') {
-            String publicationName = 'maven'
-            MavenPublication publication = createPublication(publicationName, project, extension)
-            new JavaAttachments(publicationName, project).attachTo(publication)
+            def mavenPublication = project.publishing.publications.find { it.name == 'maven' }
+            if (mavenPublication == null) {
+                String publicationName = 'maven'
+                MavenPublication publication = createPublication(publicationName, project, extension)
+                new JavaAttachments(publicationName, project).attachTo(publication)
+            }
         }
     }
 


### PR DESCRIPTION
This change is intended to fully customize the pom file as you like, by defining your own publication. This should resolve #266 