### PR TITLE
support gradle 4.10.1+

### DIFF
--- a/plugin/core/src/main/groovy/com/novoda/gradle/release/MavenPublicationAttachments.groovy
+++ b/plugin/core/src/main/groovy/com/novoda/gradle/release/MavenPublicationAttachments.groovy
@@ -3,6 +3,7 @@ package com.novoda.gradle.release
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.provider.Provider
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Javadoc
@@ -26,15 +27,15 @@ class MavenPublicationAttachments {
         publication.from softwareComponent
     }
 
-    protected static Task sourcesJarTask(Project project, String publicationName, def ... sourcePaths) {
-        return project.task("generateSourcesJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
+    protected static Provider<Task> sourcesJarTask(Project project, String publicationName, def ... sourcePaths) {
+        return project.task("genereateSourcesJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
             jar.classifier = 'sources'
             jar.from sourcePaths
         }
     }
 
-    protected static Task javadocsJarTask(Project project, String publicationName, Javadoc javadoc) {
-        return project.task("generateJavadocsJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
+    protected static Provider<Task> javadocsJarTask(Project project, String publicationName, Javadoc javadoc) {
+        return project.task("genereateJavadocsJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
             jar.classifier = 'javadoc'
             jar.from project.files(javadoc)
         }

--- a/plugin/core/src/main/groovy/com/novoda/gradle/release/MavenPublicationAttachments.groovy
+++ b/plugin/core/src/main/groovy/com/novoda/gradle/release/MavenPublicationAttachments.groovy
@@ -28,14 +28,14 @@ class MavenPublicationAttachments {
     }
 
     protected static Provider<Task> sourcesJarTask(Project project, String publicationName, def ... sourcePaths) {
-        return project.task("genereateSourcesJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
+        return project.tasks.register("genereateSourcesJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
             jar.classifier = 'sources'
             jar.from sourcePaths
         }
     }
 
     protected static Provider<Task> javadocsJarTask(Project project, String publicationName, Javadoc javadoc) {
-        return project.task("genereateJavadocsJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
+        return project.tasks.register("genereateJavadocsJarFor${publicationName.capitalize()}Publication", type: Jar) { Jar jar ->
             jar.classifier = 'javadoc'
             jar.from project.files(javadoc)
         }

--- a/plugin/core/src/main/groovy/com/novoda/gradle/release/internal/AndroidAttachments.groovy
+++ b/plugin/core/src/main/groovy/com/novoda/gradle/release/internal/AndroidAttachments.groovy
@@ -41,13 +41,24 @@ class AndroidAttachments extends MavenPublicationAttachments {
 
     private static Task androidJavadocsJarTask(Project project, String publicationName, def variant) {
         Javadoc javadoc = project.task("javadoc${publicationName.capitalize()}", type: Javadoc) { Javadoc javadoc ->
-            javadoc.source = variant.javaCompiler.source
-            javadoc.classpath = variant.javaCompiler.classpath
+            if (variant.hasProperty('javaCompileProvider')) {
+                // Gradle 4.10.1+ Android 3.3.0+
+                javadoc.source = variant.javaCompilerProvider().get().source
+                javadoc.classpath = variant.javaCompilerProvider().get().classpath
+            } else {
+                javadoc.source = variant.javaCompiler.source
+                javadoc.classpath = variant.javaCompiler.classpath
+            }
         } as Javadoc
         return javadocsJarTask(project, publicationName, javadoc)
     }
 
     private static def androidArchivePath(def variant) {
-        return variant.outputs[0].packageLibrary
+        if (variant.hasProperty('javaCompileProvider')) {
+            // Gradle 4.10.1+ Android 3.3.0+
+            return variant.outputs[0].packageLibraryProvider().get()
+        } else {
+            return variant.outputs[0].packageLibrary
+        }
     }
 }

--- a/plugin/core/src/main/groovy/com/novoda/gradle/release/internal/JavaAttachments.groovy
+++ b/plugin/core/src/main/groovy/com/novoda/gradle/release/internal/JavaAttachments.groovy
@@ -4,6 +4,7 @@ import com.novoda.gradle.release.MavenPublicationAttachments
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 
@@ -19,13 +20,13 @@ class JavaAttachments extends MavenPublicationAttachments {
         return project.components.getByName('java')
     }
 
-    private static Task javaSourcesJarTask(Project project, String publicationName) {
+    private static Provider<Task> javaSourcesJarTask(Project project, String publicationName) {
         JavaCompile javaCompile = project.compileJava
-        return sourcesJarTask(project, publicationName, javaCompile.source)
+        return sourcesJarTask(project, publicationName, javaCompile.source).get()
     }
 
-    private static Task javaJavadocsJarTask(Project project, String publicationName) {
+    private static Provider<Task> javaJavadocsJarTask(Project project, String publicationName) {
         Javadoc javadoc = project.javadoc
-        return javadocsJarTask(project, publicationName, javadoc)
+        return javadocsJarTask(project, publicationName, javadoc).get()
     }
 }


### PR DESCRIPTION
fix [#260](https://github.com/novoda/bintray-release/issues/260) API 'variantOutput.getPackageLibrary()' is obsolete