### PR TITLE
Use composite builds in functional tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.novoda:bintray-release:0.8.0'
-    }
-}
-
 subprojects {
     repositories {
         jcenter()

--- a/plugin/core/build.gradle
+++ b/plugin/core/build.gradle
@@ -1,13 +1,5 @@
-plugins {
-    id 'groovy'
-    id 'java-gradle-plugin'
-    id 'com.novoda.build-properties' version '0.4.1'
-}
-
-version = '0.9'
-
-apply plugin: 'com.novoda.bintray-release'
-apply from: 'publish.gradle'
+apply plugin: 'groovy'
+apply plugin: 'java-gradle-plugin'
 apply from: 'compat.gradle'
 
 dependencies {

--- a/plugin/core/compat.gradle
+++ b/plugin/core/compat.gradle
@@ -25,17 +25,23 @@ compatModulesDirs.each { File moduleDir ->
     def moduleName = moduleDir.name
 
     def cleanModuleTask = taskContainer.create(name: "clean${moduleName.capitalize()}", type: Delete) {
+        group = 'build'
+        description = "Clean compat module $moduleName"
         delete new File(moduleDir, 'build')
     }
     taskContainer.clean.dependsOn cleanModuleTask
 
     def compileModuleTask = taskContainer.create(name: "compile${moduleName.capitalize()}Classes", type: Exec) {
+        group = 'build'
+        description = "Build compat module $moduleName"
         outputs.dir(new File(moduleDir, 'build'))
         workingDir moduleDir
         commandLine gw, 'clean', 'build'
     }
 
     def copyClassesTask = taskContainer.create(name: "copy${moduleName.capitalize()}Classes", type: Copy) {
+        group = 'build'
+        description = "Copy classes from module $moduleName"
         from new File(moduleDir, 'build/classes/groovy/main')
         into compatClassesDestination
         dependsOn compileModuleTask

--- a/plugin/core/compat.gradle
+++ b/plugin/core/compat.gradle
@@ -4,7 +4,7 @@ String gw = Os.isFamily(Os.FAMILY_WINDOWS) ? 'gradlew.bat' : './gradlew'
 String compatClassesDestination = 'build/compat/classes'
 TaskContainer taskContainer = project.tasks
 
-File[] compatModulesDirs = rootProject.file('plugin/compat').listFiles(new FilenameFilter() {
+File[] compatModulesDirs = project.file('../compat').listFiles(new FilenameFilter() {
 
     /**
      * We want to collect all the folders inside plugin/compat that are also standalone Gradle projects,

--- a/plugin/core/publish.gradle
+++ b/plugin/core/publish.gradle
@@ -1,3 +1,20 @@
+version = '0.9'
+
+apply from: 'build.gradle'
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
+        classpath 'com.novoda:bintray-release:+'
+    }
+}
+
+apply plugin: 'com.novoda.build-properties'
+apply plugin: 'com.novoda.bintray-release'
+
 buildProperties {
     cli {
         using(project)

--- a/plugin/functional-tests/build.gradle
+++ b/plugin/functional-tests/build.gradle
@@ -1,14 +1,13 @@
-plugins {
-    id 'groovy'
-    id 'java-gradle-plugin'
+repositories {
+    jcenter()
 }
+
+apply plugin: 'groovy'
 
 dependencies {
     implementation project(':core')
-    implementation 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 
     testImplementation gradleTestKit()
-    testRuntime files(pluginUnderTestMetadata)
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.42'
 }

--- a/plugin/functional-tests/src/test/gradle/build.gradle
+++ b/plugin/functional-tests/src/test/gradle/build.gradle
@@ -1,0 +1,1 @@
+apply from: '../../../../../build.gradle'

--- a/plugin/functional-tests/src/test/gradle/settings.gradle
+++ b/plugin/functional-tests/src/test/gradle/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'bintray-release-local'
+
+include ':core'
+project(':core').projectDir = file('../../../../core')

--- a/plugin/functional-tests/src/test/groovy/com/novoda/gradle/release/InvalidExtensionSetupTest.groovy
+++ b/plugin/functional-tests/src/test/groovy/com/novoda/gradle/release/InvalidExtensionSetupTest.groovy
@@ -8,10 +8,20 @@ import org.junit.Test
 class InvalidExtensionSetupTest {
 
     private String buildScript = """
+            buildscript {
+                repositories {
+                    jcenter()
+                }
+                dependencies {
+                    classpath 'com.novoda:bintray-release:local'
+                }
+            }
+            
             plugins { 
                 id 'java-library'
-                id 'com.novoda.bintray-release'
             }
+            
+            apply plugin: 'com.novoda.bintray-release'
             
             publish {
                 userOrg = 'novoda'

--- a/plugin/functional-tests/src/test/groovy/com/novoda/gradle/test/Fixtures.groovy
+++ b/plugin/functional-tests/src/test/groovy/com/novoda/gradle/test/Fixtures.groovy
@@ -3,6 +3,7 @@ package com.novoda.gradle.test
 final class Fixtures {
 
     public static final File BUILD_DIR = findBuildDir()
+    public static final File ROOT_DIR = BUILD_DIR.parentFile
 
     private static File findBuildDir() {
         def start = new File(getResource('.').file)

--- a/plugin/functional-tests/src/test/groovy/com/novoda/gradle/test/GradleScriptTemplates.groovy
+++ b/plugin/functional-tests/src/test/groovy/com/novoda/gradle/test/GradleScriptTemplates.groovy
@@ -4,9 +4,17 @@ class GradleScriptTemplates {
 
     static String forJavaProject() {
         return """
+            buildscript {
+                repositories {
+                    jcenter()
+                }
+                dependencies {
+                    classpath 'com.novoda:bintray-release:local'
+                }
+            }
+            
             plugins { 
                 id 'java-library'
-                id 'com.novoda.bintray-release'
             }
             
             repositories {
@@ -16,6 +24,8 @@ class GradleScriptTemplates {
             dependencies {
                 implementation "junit:junit:4.12"
             }
+            
+            apply plugin: 'com.novoda.bintray-release'
             
             publish {
                 userOrg = 'novoda'
@@ -36,14 +46,17 @@ class GradleScriptTemplates {
                 }
                 dependencies {
                     classpath 'com.android.tools.build:gradle:$androidGradlePluginVersion'
+                    classpath 'com.novoda:bintray-release:local'
                 }
             }
             
-            plugins {
-                id 'com.novoda.bintray-release'
+            repositories {
+                google()
+                jcenter()
             }
             
-            apply plugin: "com.android.library"
+            apply plugin: 'com.android.library'
+            apply plugin: 'com.novoda.bintray-release'
             
             android {
                 compileSdkVersion 26
@@ -58,11 +71,6 @@ class GradleScriptTemplates {
                 lintOptions {
                    tasks.lint.enabled = false
                 }
-            }
-            
-            repositories {
-                google()
-                jcenter()
             }
             
             publish {

--- a/plugin/functional-tests/src/test/groovy/com/novoda/gradle/test/TestProject.groovy
+++ b/plugin/functional-tests/src/test/groovy/com/novoda/gradle/test/TestProject.groovy
@@ -96,7 +96,15 @@ class TestProject implements TestRule {
 
     private void createSettingsScript() {
         new File(projectDir, 'settings.gradle').with {
-            text = "rootProject.name = 'test'"
+            text = """
+                    rootProject.name = 'test'
+                    
+                    includeBuild('$Fixtures.ROOT_DIR/src/test/gradle') {
+                        dependencySubstitution {
+                            substitute module('com.novoda:bintray-release:local') with project(':core')
+                        }
+                    }
+                """.stripIndent()
         }
     }
 
@@ -107,7 +115,6 @@ class TestProject implements TestRule {
     GradleBuildResult execute(String... arguments) {
         def runner = GradleRunner.create()
                 .forwardOutput()
-                .withPluginClasspath()
                 .withProjectDir(projectDir)
         additionalRunnerConfig.execute(runner)
         runner.withArguments(arguments)

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'bintray-release'
 
 include ':core'
 project(':core').projectDir = file('plugin/core')
+project(':core').buildFileName = 'publish.gradle'
 
 include ':functional-tests'
 project(':functional-tests').projectDir = file('plugin/functional-tests')


### PR DESCRIPTION
Follow-up work of #276. Aim is to avoid to rely on the `java-gradle-plugin` magic to inject the classpath of the functional tests with a local copy of the plugin, and use composite builds instead.
The main advantage of this is that the test projects generated as part of the functional tests can be then re-built and debugged without issues.

## Implementation details
- A synthetic gradle project (`plugin/functional-tests/src/test/gradle`) has been introduced to be used along with composite builds
- In order to avoid issues with the publication configuration the buildscripts in `:core` have been re-arranged:
  - when `:core` is included in the main Gradle project, its buildscript will include the Bintray configuration, see `plugin/core/publish.gradle`
  - when `:core` is included via composite build in the functional tests will instead be using `plugin/core/build.gradle` as build file
- the templates used to generate the gradle projects for the functional tests now ship with a composite build configuration ensuring that they build against a local copy of the `bintray-release` plugin without any need of deployments anywhere.