### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ configure<PublishExtension> {
 }
 ```
 
-Finally, use the task `bintrayUpload` to publish (make sure you build the project first!):
+Finally, use the task `bintrayUpload` to publish. Make sure:
+ - You build the project first!
+ - If this is your first time; create the package on Bintray first with the 'Add a package' button.
+ - The name of the package on Bintray matches the `artifactId` of the `publish` clojure in `build.gradle.`
 
 ```bash
 $ ./gradlew clean build bintrayUpload -PbintrayUser=BINTRAY_USERNAME -PbintrayKey=BINTRAY_KEY -PdryRun=false


### PR DESCRIPTION
Hey guyyyzzz,

I was adding the plugin to a new library and followed the README, it didn't explain a step (I think in the past perhaps this step wasn't neccesary?)

Explain how to avoid this error:

```
* What went wrong:
Execution failed for task ':bintrayPublish'.
> Could not publish 'blundell/maven/some-library-name/0.0.1': HTTP/1.1 404 Not Found [message:Package 'some-library-name' was not found]
```

Also feel free to tell me I'm wrong here, and my error was for another reason :-)

![image](https://user-images.githubusercontent.com/655860/70453646-09852900-1aa1-11ea-9a4f-f7e3c8e9a990.png)
